### PR TITLE
All overriding methods must be annotated with @Override

### DIFF
--- a/adapter/persistence/src/main/java/org/apache/rocketmq/eventbridge/adapter/persistence/rule/mybatis/repository/MybatisEventRuleRepository.java
+++ b/adapter/persistence/src/main/java/org/apache/rocketmq/eventbridge/adapter/persistence/rule/mybatis/repository/MybatisEventRuleRepository.java
@@ -59,6 +59,7 @@
          return eventRuleMapper.deleteEventRule(accountId, eventBusName, eventRuleName) == 1;
      }
 
+     @Override
      public EventRule getEventRule(String accountId, String eventBusName, String eventRuleName) {
          return eventRuleMapper.getEventRule(accountId, eventBusName, eventRuleName);
 

--- a/adapter/rpc/src/main/java/org/apache/rocketmq/eventbridge/adapter/rpc/impl/connect/dto/DeleteConnectorRequest.java
+++ b/adapter/rpc/src/main/java/org/apache/rocketmq/eventbridge/adapter/rpc/impl/connect/dto/DeleteConnectorRequest.java
@@ -32,6 +32,7 @@ public class DeleteConnectorRequest extends BaseConnectorRequest {
         super(endpoint);
     }
 
+    @Override
     public String toString() {
         return String.format(endpoint + path, name);
     }

--- a/adapter/rpc/src/main/java/org/apache/rocketmq/eventbridge/adapter/rpc/impl/connect/dto/GetConnectorStatusRequest.java
+++ b/adapter/rpc/src/main/java/org/apache/rocketmq/eventbridge/adapter/rpc/impl/connect/dto/GetConnectorStatusRequest.java
@@ -32,6 +32,7 @@ public class GetConnectorStatusRequest extends BaseConnectorRequest {
         super(endpoint);
     }
 
+    @Override
     public String toString() {
         return String.format(endpoint + path, name);
     }

--- a/adapter/rpc/src/main/java/org/apache/rocketmq/eventbridge/adapter/rpc/impl/connect/dto/StartConnectorRequest.java
+++ b/adapter/rpc/src/main/java/org/apache/rocketmq/eventbridge/adapter/rpc/impl/connect/dto/StartConnectorRequest.java
@@ -32,6 +32,7 @@ public class StartConnectorRequest extends BaseConnectorRequest {
         super(endpoint);
     }
 
+    @Override
     public String toString() {
         return String.format(endpoint + path, name);
     }

--- a/adapter/rpc/src/main/java/org/apache/rocketmq/eventbridge/adapter/rpc/impl/connect/dto/StopConnectorRequest.java
+++ b/adapter/rpc/src/main/java/org/apache/rocketmq/eventbridge/adapter/rpc/impl/connect/dto/StopConnectorRequest.java
@@ -32,6 +32,7 @@ public class StopConnectorRequest extends BaseConnectorRequest {
         super(endpoint);
     }
 
+    @Override
     public String toString() {
         return String.format(endpoint + path, name);
     }

--- a/start/src/main/java/org/apache/rocketmq/eventbridge/Main.java
+++ b/start/src/main/java/org/apache/rocketmq/eventbridge/Main.java
@@ -22,7 +22,6 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-@ComponentScan
 @EnableCaching
 public class Main {
     public static void main(String[] args) {


### PR DESCRIPTION
All overriding methods must be annotated with @Override.Redundant declaration: @SpringBootApplication already applies given @ComponentScan.