### PR TITLE
bugfix:  fix resourceOwnerIds fetch exception

### DIFF
--- a/infrastructure/src/main/java/org/apache/rocketmq/eventbridge/infrastructure/validate/DefaultAuthValidation.java
+++ b/infrastructure/src/main/java/org/apache/rocketmq/eventbridge/infrastructure/validate/DefaultAuthValidation.java
@@ -17,12 +17,10 @@
 
 package org.apache.rocketmq.eventbridge.infrastructure.validate;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import reactor.util.context.Context;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.apache.rocketmq.eventbridge.enums.props.Constants.HEADER_KEY_RESOURCE_OWNER_ACCOUNT_ID;
 

--- a/infrastructure/src/main/java/org/apache/rocketmq/eventbridge/infrastructure/validate/DefaultAuthValidation.java
+++ b/infrastructure/src/main/java/org/apache/rocketmq/eventbridge/infrastructure/validate/DefaultAuthValidation.java
@@ -17,10 +17,12 @@
 
 package org.apache.rocketmq.eventbridge.infrastructure.validate;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import reactor.util.context.Context;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.rocketmq.eventbridge.enums.props.Constants.HEADER_KEY_RESOURCE_OWNER_ACCOUNT_ID;
 
@@ -32,7 +34,7 @@ public class DefaultAuthValidation implements AuthValidation {
     @Override
     public Context validate(ServerHttpRequest request, Context ctx) {
         String resourceOwnerId = "default";
-        List<String> resourceOwnerIds = request.getHeaders().get(HEADER_KEY_RESOURCE_OWNER_ACCOUNT_ID);
+        List<String> resourceOwnerIds = request.getHeaders().get(HEADER_KEY_RESOURCE_OWNER_ACCOUNT_ID.getName());
         if (resourceOwnerIds != null && !resourceOwnerIds.isEmpty()) {
             //throw new EventBridgeException(DefaultErrorCode.LoginFailed);
             resourceOwnerId = resourceOwnerIds.get(0);


### PR DESCRIPTION
When starting eventbridge as a file, an error occurs in obtaining resourceOwnerId


target-runner.json
```
[
  {
    "name":"demo-runner",
    "components":[
      {
        "accountId": "654321",
        "runnerName": "test1",
        "eventBusName":"demo-bus"
      },
      {
        "filterPattern":"{}",
        "class":"org.apache.rocketmq.connect.transform.eventbridge.EventBridgeFilterTransform"
      },
      {
        "data":"{\"form\":\"TEMPLATE\",\"value\":\"{\\\"content\\\":\\\"$.data.body\\\"}\",\"template\":\"{\\\"text\\\":{\\\"content\\\":\\\"${content}\\\"},\\\"msgtype\\\":\\\"text\\\"}\"}",
        "class": "org.apache.rocketmq.connect.transform.eventbridge.EventBridgeTransform"
      },
      {
        "class":"org.apache.rocketmq.connect.dingtalk.sink.DingTalkSinkTask",
        "webHook":"xxxxxxxxxxx",
        "secretKey":"xxxxxxxxxxx"
      }
    ]
  }
]
```

As shown in the figure, resourceOwnerIds already exists in the request header, but the DefaultAuthValidation#validate method fails to judge

![575675675676](https://github.com/apache/rocketmq-eventbridge/assets/20021404/80eaedab-29b1-4ffa-a1f9-01dc553bea14)
