### PR TITLE
bugfix: add default default

### DIFF
--- a/adapter/rpc/src/main/java/org/apache/rocketmq/eventbridge/adapter/rpc/impl/AppConfigAPIImpl.java
+++ b/adapter/rpc/src/main/java/org/apache/rocketmq/eventbridge/adapter/rpc/impl/AppConfigAPIImpl.java
@@ -34,6 +34,7 @@ public class AppConfigAPIImpl {
         Set<String> extensionKeys = Sets.newHashSet();
         extensionKeys.add("aliyuneventbusname");
         globalConfig.setEventExtensionKeys(extensionKeys);
+        globalConfig.setDefaultDataPersistentClusterName("aliyuneventbuscluster");
 
         LocalConfig localConfig = new LocalConfig();
         localConfig.setRegion("cn-hangzhou");


### PR DESCRIPTION
Failed to create topic when creating context from global instance information configuration

![6456hgfhgfhgh](https://github.com/apache/rocketmq-eventbridge/assets/20021404/445e5225-8994-4336-92dc-224294734b16)

reason:
![674766765756](https://github.com/apache/rocketmq-eventbridge/assets/20021404/a942c67c-cb01-4632-9daf-124fc89b5418)
